### PR TITLE
Pin fatrw to rev instead of tag as it is better supported by yocto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,7 +594,7 @@ dependencies = [
 [[package]]
 name = "fatrw"
 version = "0.1.10"
-source = "git+https://github.com/balena-os/fatrw?tag=v0.1.10#04629a208b9035d642e51db54886f3d39d7ee029"
+source = "git+https://github.com/balena-os/fatrw?rev=04629a208b9035d642e51db54886f3d39d7ee029#04629a208b9035d642e51db54886f3d39d7ee029"
 dependencies = [
  "anyhow 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1159,7 +1159,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fatrw 0.1.10 (git+https://github.com/balena-os/fatrw?tag=v0.1.10)",
+ "fatrw 0.1.10 (git+https://github.com/balena-os/fatrw?rev=04629a208b9035d642e51db54886f3d39d7ee029)",
  "flate2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2354,7 +2354,7 @@ dependencies = [
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
-"checksum fatrw 0.1.10 (git+https://github.com/balena-os/fatrw?tag=v0.1.10)" = "<none>"
+"checksum fatrw 0.1.10 (git+https://github.com/balena-os/fatrw?rev=04629a208b9035d642e51db54886f3d39d7ee029)" = "<none>"
 "checksum flate2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "246b6f24d8e616b0c176a8143486ddc8bb0bac2f30f0a0d3efbcf1e0d47cb7e5"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ features = ["ssl"]
 
 [dependencies.fatrw]
 git = "https://github.com/balena-os/fatrw"
-tag = "v0.1.10"
+rev = "04629a208b9035d642e51db54886f3d39d7ee029"
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
Current fatrw tag remains v0.1.10.

Change-type: patch
Signed-off-by: Zahari Petkov <zahari@balena.io>