### PR TITLE
Fix clippy warnings introduced in Rust 1.67

### DIFF
--- a/src/config_json.rs
+++ b/src/config_json.rs
@@ -220,7 +220,7 @@ fn get_api_key_for_endpoint(config_json: &ConfigMap, api_endpoint: &str) -> Resu
 }
 
 pub fn read_config_json(path: &Path) -> Result<ConfigMap> {
-    read_json_object_file(path).context(format!("Reading {:?} failed", path))
+    read_json_object_file(path).context(format!("Reading {path:?} failed"))
 }
 
 fn read_json_object_file(path: &Path) -> Result<ConfigMap> {
@@ -240,7 +240,7 @@ fn json_object_from_string(contents: &str) -> Result<ConfigMap> {
 }
 
 pub fn write_config_json(path: &Path, map: &ConfigMap) -> Result<()> {
-    write_json_object_file(path, map).context(format!("Writing {:?} failed", path))
+    write_json_object_file(path, map).context(format!("Writing {path:?} failed"))
 }
 
 fn write_json_object_file(path: &Path, map: &ConfigMap) -> Result<()> {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -20,8 +20,7 @@ pub fn write_file(path: &Path, contents: &str, mode: Option<u32>) -> Result<()> 
 pub fn parse_mode(mode: &str) -> Result<Option<u32>> {
     if !mode.is_empty() {
         Ok(Some(u32::from_str_radix(mode, 8).context(format!(
-            "Parsing permission mode `{}` failed",
-            mode
+            "Parsing permission mode `{mode}` failed"
         ))?))
     } else {
         Ok(None)

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -39,7 +39,7 @@ impl Configuration {
 }
 
 pub fn config_url(api_endpoint: &str, config_route: &str) -> String {
-    format!("{}{}", api_endpoint, config_route)
+    format!("{api_endpoint}{config_route}")
 }
 
 pub fn fetch_configuration(
@@ -91,7 +91,7 @@ fn retry_request_config(url: &str, client: &reqwest::Client) -> Result<reqwest::
             }
             Err(err) => {
                 // Print the same error only once.
-                let curr_err = format!("{}", err);
+                let curr_err = format!("{err}");
                 if last_err != curr_err {
                     info!("{}", curr_err);
                     last_err = curr_err;

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -15,12 +15,12 @@ const DEFAULT_MODE: &str = "replace";
 const MOCK_SYSTEMD: &str = "MOCK_SYSTEMD";
 
 pub fn start_service(name: &str) -> Result<()> {
-    info!("Starting {}...", name);
+    info!("Starting {name}...");
 
     if should_mock_systemd() {
         return Ok(());
     }
-    start_service_impl(name).context(format!("Starting {} failed", name))
+    start_service_impl(name).context(format!("Starting {name} failed"))
 }
 
 fn start_service_impl(name: &str) -> Result<()> {
@@ -34,12 +34,12 @@ fn start_service_impl(name: &str) -> Result<()> {
 }
 
 pub fn stop_service(name: &str) -> Result<()> {
-    info!("Stopping {}...", name);
+    info!("Stopping {name}...");
 
     if should_mock_systemd() {
         return Ok(());
     }
-    stop_service_impl(name).context(format!("Stopping {} failed", name))
+    stop_service_impl(name).context(format!("Stopping {name} failed"))
 }
 
 fn stop_service_impl(name: &str) -> Result<()> {
@@ -53,12 +53,12 @@ fn stop_service_impl(name: &str) -> Result<()> {
 }
 
 pub fn reload_or_restart_service(name: &str) -> Result<()> {
-    info!("Reloading or restarting {}...", name);
+    info!("Reloading or restarting {name}...");
 
     if should_mock_systemd() {
         return Ok(());
     }
-    reload_or_restart_service_impl(name).context(format!("Reloading or restarting {} failed", name))
+    reload_or_restart_service_impl(name).context(format!("Reloading or restarting {name} failed"))
 }
 
 fn reload_or_restart_service_impl(name: &str) -> Result<()> {
@@ -72,12 +72,12 @@ fn reload_or_restart_service_impl(name: &str) -> Result<()> {
 }
 
 pub fn await_service_exit(name: &str) -> Result<()> {
-    info!("Awaiting {} to exit...", name);
+    info!("Awaiting {name} to exit...");
 
     if should_mock_systemd() {
         return Ok(());
     }
-    await_service_exit_impl(name).context(format!("Awaiting {} to exit failed", name))
+    await_service_exit_impl(name).context(format!("Awaiting {name} to exit failed"))
 }
 
 fn await_service_exit_impl(name: &str) -> Result<()> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -69,7 +69,7 @@ fn join() {
                     "id": "not-a-service-1",
                     "files": {{
                         "main": {{
-                            "path": "{0}/not-a-service-1.conf",
+                            "path": "{tmp_dir_path}/not-a-service-1.conf",
                             "perm": "755"
                         }}
                     }},
@@ -80,11 +80,11 @@ fn join() {
                     "id": "mock-1-2",
                     "files": {{
                         "mock-1": {{
-                            "path": "{0}/mock-1.conf",
+                            "path": "{tmp_dir_path}/mock-1.conf",
                             "perm": "600"
                         }},
                         "mock-2": {{
-                            "path": "{0}/mock-2.conf",
+                            "path": "{tmp_dir_path}/mock-2.conf",
                             "perm": "755"
                         }}
                     }},
@@ -95,7 +95,7 @@ fn join() {
                     "id": "mock-3",
                     "files": {{
                         "mock-3": {{
-                            "path": "{0}/mock-3.conf",
+                            "path": "{tmp_dir_path}/mock-3.conf",
                             "perm": ""
                         }}
                     }},
@@ -106,8 +106,7 @@ fn join() {
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
             "schema_version": "1.0.0"
         }}
-        "#,
-        tmp_dir_path
+        "#
     );
 
     let os_config_path = create_tmp_file(&tmp_dir, "os-config.json", &schema, None);
@@ -165,23 +164,22 @@ fn join() {
         Service configuration retrieved
         Stopping balena-supervisor.service...
         Awaiting balena-supervisor.service to exit...
-        Writing {0}/config.json
-        {0}/not-a-service-1.conf updated
+        Writing {tmp_dir_path}/config.json
+        {tmp_dir_path}/not-a-service-1.conf updated
         Stopping mock-service-1.service...
         Stopping mock-service-2.service...
         Awaiting mock-service-1.service to exit...
         Awaiting mock-service-2.service to exit...
-        {0}/mock-1.conf updated
-        {0}/mock-2.conf updated
+        {tmp_dir_path}/mock-1.conf updated
+        {tmp_dir_path}/mock-2.conf updated
         Starting mock-service-1.service...
         Starting mock-service-2.service...
         Stopping mock-service-3.service...
         Awaiting mock-service-3.service to exit...
-        {0}/mock-3.conf updated
+        {tmp_dir_path}/mock-3.conf updated
         Starting mock-service-3.service...
         Starting balena-supervisor.service...
-        "#,
-        tmp_dir_path
+        "#
     ));
 
     get_base_command()
@@ -192,25 +190,25 @@ fn join() {
         .stdout(output);
 
     validate_file(
-        &format!("{}/not-a-service-1.conf", tmp_dir_path),
+        &format!("{tmp_dir_path}/not-a-service-1.conf"),
         "NO-SYSTEMD\n0123456789\n0123456789\n0123456789\n0123456789\n",
         Some(0o755),
     );
 
     validate_file(
-        &format!("{}/mock-1.conf", tmp_dir_path),
+        &format!("{tmp_dir_path}/mock-1.conf"),
         "MOCK-1-АБВГДЕЖЗИЙ",
         Some(0o600),
     );
 
     validate_file(
-        &format!("{}/mock-2.conf", tmp_dir_path),
+        &format!("{tmp_dir_path}/mock-2.conf"),
         "MOCK-2-0123456789",
         Some(0o755),
     );
 
     validate_file(
-        &format!("{}/mock-3.conf", tmp_dir_path),
+        &format!("{tmp_dir_path}/mock-3.conf"),
         "MOCK-3-0123456789",
         None,
     );
@@ -277,7 +275,7 @@ fn join_flasher() {
                     "id": "mock-1",
                     "files": {{
                         "mock-1": {{
-                            "path": "{0}/mock-1.conf",
+                            "path": "{tmp_dir_path}/mock-1.conf",
                             "perm": "600"
                         }}
                     }},
@@ -287,8 +285,7 @@ fn join_flasher() {
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
             "schema_version": "1.0.0"
         }}
-        "#,
-        tmp_dir_path
+        "#
     );
 
     let os_config_path = create_tmp_file(&tmp_dir, "os-config.json", &schema, None);
@@ -339,14 +336,13 @@ fn join_flasher() {
         Service configuration retrieved
         Stopping balena-supervisor.service...
         Awaiting balena-supervisor.service to exit...
-        Writing {0}/config.json
+        Writing {tmp_dir_path}/config.json
         Stopping mock-service-1.service...
         Awaiting mock-service-1.service to exit...
-        {0}/mock-1.conf updated
+        {tmp_dir_path}/mock-1.conf updated
         Starting mock-service-1.service...
         Starting balena-supervisor.service...
         "#,
-        tmp_dir_path
     ));
 
     get_base_command()
@@ -359,7 +355,7 @@ fn join_flasher() {
         .stdout(output);
 
     validate_file(
-        &format!("{}/mock-1.conf", tmp_dir_path),
+        &format!("{tmp_dir_path}/mock-1.conf"),
         "MOCK-1-АБВГДЕЖЗИЙ",
         Some(0o600),
     );
@@ -473,10 +469,9 @@ fn join_with_root_certificate() {
         No configuration changes
         Stopping balena-supervisor.service...
         Awaiting balena-supervisor.service to exit...
-        Writing {0}/config.json
+        Writing {tmp_dir_path}/config.json
         Starting balena-supervisor.service...
-        "#,
-        tmp_dir_path
+        "#
     ));
 
     get_base_command()
@@ -548,7 +543,7 @@ fn join_no_endpoint() {
                     "id": "mock-1",
                     "files": {{
                         "mock-1": {{
-                            "path": "{0}/mock-1.conf",
+                            "path": "{tmp_dir_path}/mock-1.conf",
                             "perm": "600"
                         }}
                     }},
@@ -558,8 +553,7 @@ fn join_no_endpoint() {
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
             "schema_version": "1.0.0"
         }}
-        "#,
-        tmp_dir_path
+        "#
     );
 
     let os_config_path = create_tmp_file(&tmp_dir, "os-config.json", &schema, None);
@@ -776,7 +770,7 @@ fn reconfigure() {
             "appUpdatePollInterval": 60000,
             "listenPort": 48484,
             "vpnPort": 443,
-            "apiEndpoint": "http://{}",
+            "apiEndpoint": "http://{0}",
             "vpnEndpoint": "vpn.resin.io",
             "registryEndpoint": "registry2.resin.io",
             "deltaEndpoint": "https://delta.resin.io",
@@ -797,10 +791,9 @@ fn reconfigure() {
         No configuration changes
         Stopping balena-supervisor.service...
         Awaiting balena-supervisor.service to exit...
-        Writing {0}/config.json
+        Writing {tmp_dir_path}/config.json
         Starting balena-supervisor.service...
-        "#,
-        tmp_dir_path
+        "#
     ));
 
     get_base_command()
@@ -940,10 +933,9 @@ fn reconfigure_stored() {
         No configuration changes
         Stopping balena-supervisor.service...
         Awaiting balena-supervisor.service to exit...
-        Writing {0}/config.json
+        Writing {tmp_dir_path}/config.json
         Starting balena-supervisor.service...
-        "#,
-        tmp_dir_path
+        "#
     ));
 
     get_base_command()
@@ -1038,7 +1030,7 @@ fn update() {
                     "id": "not-a-service-1",
                     "files": {{
                         "main": {{
-                            "path": "{0}/not-a-service-1.conf",
+                            "path": "{tmp_dir_path}/not-a-service-1.conf",
                             "perm": "755"
                         }}
                     }},
@@ -1049,11 +1041,11 @@ fn update() {
                     "id": "mock-1-2",
                     "files": {{
                         "mock-1": {{
-                            "path": "{0}/mock-1.conf",
+                            "path": "{tmp_dir_path}/mock-1.conf",
                             "perm": "600"
                         }},
                         "mock-2": {{
-                            "path": "{0}/mock-2.conf",
+                            "path": "{tmp_dir_path}/mock-2.conf",
                             "perm": "755"
                         }}
                     }},
@@ -1064,7 +1056,7 @@ fn update() {
                     "id": "mock-3",
                     "files": {{
                         "mock-3": {{
-                            "path": "{0}/mock-3.conf",
+                            "path": "{tmp_dir_path}/mock-3.conf",
                             "perm": ""
                         }}
                     }},
@@ -1075,8 +1067,7 @@ fn update() {
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
             "schema_version": "1.0.0"
         }}
-        "#,
-        tmp_dir_path
+        "#
     );
 
     let os_config_path = create_tmp_file(&tmp_dir, "os-config.json", &schema, None);
@@ -1114,22 +1105,21 @@ fn update() {
         Service configuration retrieved
         Stopping balena-supervisor.service...
         Awaiting balena-supervisor.service to exit...
-        {0}/not-a-service-1.conf updated
+        {tmp_dir_path}/not-a-service-1.conf updated
         Stopping mock-service-1.service...
         Stopping mock-service-2.service...
         Awaiting mock-service-1.service to exit...
         Awaiting mock-service-2.service to exit...
-        {0}/mock-1.conf updated
-        {0}/mock-2.conf updated
+        {tmp_dir_path}/mock-1.conf updated
+        {tmp_dir_path}/mock-2.conf updated
         Starting mock-service-1.service...
         Starting mock-service-2.service...
         Stopping mock-service-3.service...
         Awaiting mock-service-3.service to exit...
-        {0}/mock-3.conf updated
+        {tmp_dir_path}/mock-3.conf updated
         Starting mock-service-3.service...
         Starting balena-supervisor.service...
-        "#,
-        tmp_dir_path
+        "#
     ));
 
     get_base_command()
@@ -1140,25 +1130,25 @@ fn update() {
         .stdout(predicate::str::is_match(output).unwrap());
 
     validate_file(
-        &format!("{}/not-a-service-1.conf", tmp_dir_path),
+        &format!("{tmp_dir_path}/not-a-service-1.conf"),
         "NO-SYSTEMD\n0123456789\n0123456789\n0123456789\n0123456789\n",
         Some(0o755),
     );
 
     validate_file(
-        &format!("{}/mock-1.conf", tmp_dir_path),
+        &format!("{tmp_dir_path}/mock-1.conf"),
         "MOCK-1-АБВГДЕЖЗИЙ",
         Some(0o600),
     );
 
     validate_file(
-        &format!("{}/mock-2.conf", tmp_dir_path),
+        &format!("{tmp_dir_path}/mock-2.conf"),
         "MOCK-2-0123456789",
         Some(0o755),
     );
 
     validate_file(
-        &format!("{}/mock-3.conf", tmp_dir_path),
+        &format!("{tmp_dir_path}/mock-3.conf"),
         "MOCK-3-0123456789",
         None,
     );
@@ -1213,11 +1203,11 @@ fn update_no_config_changes() {
                     "id": "mock-1-2",
                     "files": {{
                         "mock-1": {{
-                            "path": "{0}/mock-1.conf",
+                            "path": "{tmp_dir_path}/mock-1.conf",
                             "perm": "600"
                         }},
                         "mock-2": {{
-                            "path": "{0}/mock-2.conf",
+                            "path": "{tmp_dir_path}/mock-2.conf",
                             "perm": "755"
                         }}
                     }},
@@ -1228,7 +1218,7 @@ fn update_no_config_changes() {
                     "id": "mock-3",
                     "files": {{
                         "mock-3": {{
-                            "path": "{0}/mock-3.conf",
+                            "path": "{tmp_dir_path}/mock-3.conf",
                             "perm": ""
                         }}
                     }},
@@ -1239,8 +1229,7 @@ fn update_no_config_changes() {
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
             "schema_version": "1.0.0"
         }}
-        "#,
-        tmp_dir_path
+        "#
     );
 
     let os_config_path = create_tmp_file(&tmp_dir, "os-config.json", &schema, None);
@@ -1286,19 +1275,19 @@ fn update_no_config_changes() {
         .stdout(output);
 
     validate_file(
-        &format!("{}/mock-1.conf", tmp_dir_path),
+        &format!("{tmp_dir_path}/mock-1.conf"),
         "MOCK-1-АБВГДЕЖЗИЙ",
         Some(0o600),
     );
 
     validate_file(
-        &format!("{}/mock-2.conf", tmp_dir_path),
+        &format!("{tmp_dir_path}/mock-2.conf"),
         "MOCK-2-0123456789",
         Some(0o755),
     );
 
     validate_file(
-        &format!("{}/mock-3.conf", tmp_dir_path),
+        &format!("{tmp_dir_path}/mock-3.conf"),
         "MOCK-3-0123456789",
         None,
     );
@@ -1491,7 +1480,7 @@ fn leave() {
                     "id": "mock-3",
                     "files": {{
                         "mock-3": {{
-                            "path": "{0}/mock-3.conf",
+                            "path": "{tmp_dir_path}/mock-3.conf",
                             "perm": ""
                         }}
                     }},
@@ -1501,8 +1490,7 @@ fn leave() {
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint", "vpnPort", "registryEndpoint", "deltaEndpoint"],
             "schema_version": "1.0.0"
         }}
-        "#,
-        tmp_dir_path
+        "#
     );
 
     let os_config_path = create_tmp_file(&tmp_dir, "os-config.json", &schema, None);
@@ -1529,12 +1517,11 @@ fn leave() {
         Stopping balena-supervisor.service...
         Awaiting balena-supervisor.service to exit...
         Deleting config.json keys
-        Writing {0}/config.json
-        {0}/mock-3.conf deleted
+        Writing {tmp_dir_path}/config.json
+        {tmp_dir_path}/mock-3.conf deleted
         Reloading or restarting mock-service-3.service...
         Starting balena-supervisor.service...
-        "#,
-        tmp_dir_path
+        "#
     ));
 
     get_base_command()
@@ -1544,7 +1531,7 @@ fn leave() {
         .success()
         .stdout(output);
 
-    validate_does_not_exist(&format!("{}/mock-3.conf", tmp_dir_path));
+    validate_does_not_exist(&format!("{tmp_dir_path}/mock-3.conf"));
 
     validate_json_file(
         &config_json_path,
@@ -1782,9 +1769,8 @@ fn generate_api_key_reuse() {
     let output = unindent::unindent(&format!(
         r#"
         Reusing stored `deviceApiKey`
-        Writing {0}/config.json
-        "#,
-        tmp_dir_path
+        Writing {tmp_dir_path}/config.json
+        "#
     ));
 
     get_base_command()
@@ -1864,9 +1850,8 @@ fn generate_api_key_new() {
     let output = unindent::unindent(&format!(
         r#"
         New `deviceApiKey` generated
-        Writing {0}/config.json
-        "#,
-        tmp_dir_path
+        Writing {tmp_dir_path}/config.json
+        "#
     ));
 
     get_base_command()


### PR DESCRIPTION
Done automatically with `cargo clippy --fix`

Change-type: patch
Signed-off-by: Zahari Petkov <zahari@balena.io>