### PR TITLE
WIP: Move testing to Docker, fix tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM rust:1.69-bullseye
+
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY tests ./tests
+
+# Set up containerized systemd
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  systemd systemd-sysv dbus dbus-user-session libdbus-1-dev
+
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+# Build test binary now so it doesn't need to be built during actual testing
+RUN cargo test --no-run

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # os-config
+
+## Testing
+
+As `os-config` interacts with `systemd`, it's recommended to use the provided `docker-compose.yml` to run tests:
+```
+docker compose up; docker compose down
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  sut:
+    build: ./
+    stop_signal: SIGRTMIN+3
+    tty: true
+    privileged: true
+    # Specifying the tests run in a single thread isn't strictly necessary,
+    # but is useful for seeing which test is failing before the tests are fixed.
+    # This can be changed to `cargo test` in a future commit that fixes the tests.
+    command: cargo test -- --test-threads=1

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# From https://github.com/AkihiroSuda/containerized-systemd/blob/master/docker-entrypoint.sh --
+## This script works around some of the systemd features that cause it to not work well in a container,
+## so that we can run integration tests with an actual systemd, instead of a host that may not have systemd.
+
+set -e
+container=docker
+export container
+
+if [ $# -eq 0 ]; then
+	echo >&2 'ERROR: No command specified. You probably want to run `journalctl -f`, or maybe `bash`?'
+	exit 1
+fi
+
+if [ ! -t 0 ]; then
+	echo >&2 'ERROR: TTY needs to be enabled (`docker run -t ...`).'
+	exit 1
+fi
+
+env >/etc/docker-entrypoint-env
+
+cat >/etc/systemd/system/docker-entrypoint.target <<EOF
+[Unit]
+Description=the target for docker-entrypoint.service
+Requires=docker-entrypoint.service systemd-logind.service systemd-user-sessions.service
+EOF
+
+quoted_args="$(printf " %q" "${@}")"
+echo "${quoted_args}" >/etc/docker-entrypoint-cmd
+
+cat >/etc/systemd/system/docker-entrypoint.service <<EOF
+[Unit]
+Description=docker-entrypoint.service
+
+[Service]
+ExecStart=/bin/bash -exc "source /etc/docker-entrypoint-cmd"
+# EXIT_STATUS is either an exit code integer or a signal name string, see systemd.exec(5)
+ExecStopPost=/bin/bash -ec "if echo \${EXIT_STATUS} | grep [A-Z] > /dev/null; then echo >&2 \"got signal \${EXIT_STATUS}\"; systemctl exit \$(( 128 + \$( kill -l \${EXIT_STATUS} ) )); else systemctl exit \${EXIT_STATUS}; fi"
+StandardInput=tty-force
+StandardOutput=inherit
+StandardError=inherit
+WorkingDirectory=$(pwd)
+EnvironmentFile=/etc/docker-entrypoint-env
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl mask systemd-firstboot.service systemd-udevd.service systemd-modules-load.service
+systemctl unmask systemd-logind
+systemctl enable docker-entrypoint.service
+
+systemd=
+if [ -x /lib/systemd/systemd ]; then
+	systemd=/lib/systemd/systemd
+elif [ -x /usr/lib/systemd/systemd ]; then
+	systemd=/usr/lib/systemd/systemd
+elif [ -x /sbin/init ]; then
+	systemd=/sbin/init
+else
+	echo >&2 'ERROR: systemd is not installed'
+	exit 1
+fi
+systemd_args="--show-status=false --unit=docker-entrypoint.target"
+echo "$0: starting $systemd $systemd_args"
+exec $systemd $systemd_args


### PR DESCRIPTION
Because os-config makes calls to systemd and mocking that is difficult, not to mention not every host has systemd installed, tests are moved to run in a Docker container with systemd installed and modified to work with the containerized runtime.

This removes systemd as a factor that can cause tests to fail. Tests should be run as documented in the Testing section of the README, as `cargo test` will fail and also create some mock services on your dev machine that need to be manually removed if the tests don't succeed.

TODO: Some tests still fail when in Docker due to the mock API server not being reachable. Will fix this in the next commit

Change-type: patch