### PR TITLE
Switch from `tempdir` to `tempfile` for dev dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand",
  "sha1",
  "smallvec",
  "tokio",
@@ -851,12 +851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,7 +1439,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tempdir",
+ "tempfile",
  "unindent",
  "zbus",
 ]
@@ -1646,26 +1640,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1675,23 +1656,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1700,15 +1666,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.9",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1751,15 +1708,6 @@ name = "regex-syntax"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -2012,16 +1960,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]
@@ -2623,7 +2561,7 @@ dependencies = [
  "nix",
  "once_cell",
  "ordered-stream",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_repr",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ features = ["derive"]
 [dev-dependencies]
 assert_cmd = "2.0"
 maplit = "1.0"
-tempdir = "0.3"
+tempfile = "3"
 unindent = "0.1"
 predicates = "3.0"
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,7 +5,7 @@ extern crate env_logger;
 extern crate openssl;
 extern crate predicates;
 extern crate serde_json;
-extern crate tempdir;
+extern crate tempfile;
 extern crate unindent;
 
 use std::fs::{File, OpenOptions};
@@ -19,7 +19,7 @@ use std::time::Duration;
 use assert_cmd::Command;
 use predicates::prelude::*;
 
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 use actix_web::dev::ServerHandle;
 use actix_web::rt::System;
@@ -46,7 +46,7 @@ const MOCK_SYSTEMD: &str = "MOCK_SYSTEMD";
 #[test]
 fn join() {
     let port = 31001;
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
     let tmp_dir_path = tmp_dir.path().to_str().unwrap().to_string();
 
     let config_json = r#"
@@ -250,7 +250,7 @@ fn join() {
 #[test]
 fn join_flasher() {
     let port = 31002;
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
     let tmp_dir_path = tmp_dir.path().to_str().unwrap().to_string();
 
     let flasher_flag_path = create_tmp_file(&tmp_dir, "balena-image-flasher", "", None);
@@ -397,7 +397,7 @@ fn join_flasher() {
 #[test]
 fn join_with_root_certificate() {
     let port = 31003;
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
     let tmp_dir_path = tmp_dir.path().to_str().unwrap().to_string();
 
     let config_json = r#"
@@ -520,7 +520,7 @@ fn join_with_root_certificate() {
 #[test]
 fn join_no_endpoint() {
     let port = 31004;
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
     let tmp_dir_path = tmp_dir.path().to_str().unwrap().to_string();
 
     let config_json = r#"
@@ -629,7 +629,7 @@ fn join_no_endpoint() {
 #[test]
 fn incompatible_device_types() {
     let port = 31005;
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
 
     let config_json = r#"
         {
@@ -699,7 +699,7 @@ fn incompatible_device_types() {
 #[test]
 fn reconfigure() {
     let port = 31006;
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
     let tmp_dir_path = tmp_dir.path().to_str().unwrap().to_string();
 
     let config_json = r#"
@@ -842,7 +842,7 @@ fn reconfigure() {
 #[test]
 fn reconfigure_stored() {
     let port = 31007;
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
     let tmp_dir_path = tmp_dir.path().to_str().unwrap().to_string();
 
     let config_json = unindent::unindent(&format!(
@@ -987,7 +987,7 @@ fn reconfigure_stored() {
 #[test]
 fn update() {
     let port = 31008;
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
     let tmp_dir_path = tmp_dir.path().to_str().unwrap().to_string();
 
     let config_json = format!(
@@ -1160,7 +1160,7 @@ fn update() {
 #[test]
 fn update_no_config_changes() {
     let port = 31009;
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
     let tmp_dir_path = tmp_dir.path().to_str().unwrap().to_string();
 
     let config_json = format!(
@@ -1299,7 +1299,7 @@ fn update_no_config_changes() {
 #[test]
 fn update_with_root_certificate() {
     let port = 31010;
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
 
     let config_json = format!(
         r#"
@@ -1380,7 +1380,7 @@ fn update_with_root_certificate() {
 #[test]
 fn update_unmanaged() {
     let port = 31011;
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
 
     let config_json = r#"
         {
@@ -1437,7 +1437,7 @@ fn update_unmanaged() {
 #[test]
 fn leave() {
     let port = 31012;
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
     let tmp_dir_path = tmp_dir.path().to_str().unwrap().to_string();
 
     let config_json = format!(
@@ -1567,7 +1567,7 @@ fn leave() {
 #[test]
 fn leave_unmanaged() {
     let port = 31013;
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
 
     let config_json = r#"
         {
@@ -1623,7 +1623,7 @@ fn leave_unmanaged() {
 
 #[test]
 fn generate_api_key_unmanaged() {
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
 
     let config_json = r#"
         {
@@ -1666,7 +1666,7 @@ fn generate_api_key_unmanaged() {
 
 #[test]
 fn generate_api_key_already_generated() {
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
 
     let config_json = r#"
         {
@@ -1724,7 +1724,7 @@ fn generate_api_key_already_generated() {
 
 #[test]
 fn generate_api_key_reuse() {
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
     let tmp_dir_path = tmp_dir.path().to_str().unwrap().to_string();
 
     let config_json = r#"
@@ -1808,7 +1808,7 @@ fn generate_api_key_reuse() {
 
 #[test]
 fn generate_api_key_new() {
-    let tmp_dir = TempDir::new("os-config").unwrap();
+    let tmp_dir = TempDir::new().unwrap();
     let tmp_dir_path = tmp_dir.path().to_str().unwrap().to_string();
 
     let config_json = r#"


### PR DESCRIPTION
The `tempdir` crate is archived and superseded by `tempfile`.

Change-type: patch