### PR TITLE
Allow migrating of whitelisted config.json fields

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod generate;
 mod join;
 mod leave;
 mod logger;
+mod migrate;
 mod random;
 mod remote;
 mod schema;

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,0 +1,128 @@
+// Config.json migration module
+//
+// Provides methods for migrating config.json fields based on remote directives
+// from /os/vX/config. Limits migrated fields based on os-config.json schema
+// whitelist.
+
+use crate::config_json::ConfigMap;
+use crate::remote::ConfigMigrationInstructions;
+use crate::schema::OsConfigSchema;
+use anyhow::Result;
+use std::collections::HashMap;
+
+pub fn generate_config_json_migration(
+    schema: &OsConfigSchema,
+    migration_config: &ConfigMigrationInstructions,
+    config_json: &ConfigMap,
+) -> Result<ConfigMap> {
+    info!("Checking for config.json migrations...");
+
+    let mut new_config = config_json.clone();
+
+    handle_update_directives(
+        schema,
+        &migration_config.overrides,
+        config_json,
+        &mut new_config,
+    );
+
+    Ok(new_config)
+}
+
+fn handle_update_directives(
+    schema: &OsConfigSchema,
+    to_update: &HashMap<String, serde_json::Value>,
+    config_json: &ConfigMap,
+    new_config: &mut ConfigMap,
+) {
+    for key in to_update.keys() {
+        if !schema.config.whitelist.contains(key) {
+            debug!("Key `{}` not in whitelist, skipping", key);
+            continue;
+        }
+
+        if let Some(future) = to_update.get(key) {
+            if !config_json.contains_key(key) {
+                info!("Key `{}` not found, will insert", key);
+                new_config.insert(key.to_string(), future.clone());
+            } else if let Some(current) = config_json.get(key) {
+                if current != future {
+                    info!(
+                        "Key `{}` found with current value `{}`, will update to `{}`",
+                        key, current, future
+                    );
+                    new_config.insert(key.to_string(), future.clone());
+                } else {
+                    debug!(
+                        "Key `{}` found with current value `{}` equal to update value `{}`, skipping",
+                        key, current, future
+                    );
+                }
+            }
+        }
+    }
+}
+
+mod tests {
+    #[test]
+    fn test_generate_config_json_migration() {
+        let config_json = r#"
+            {
+                "deadbeef": 1,
+                "deadca1f": "2",
+                "deadca2f": true,
+                "deadca3f": "string1"
+            }
+        "#
+        .to_string();
+
+        let schema = r#"
+            {
+                "services": [
+                ],
+                "keys": [],
+                "config": {
+                    "whitelist": [
+                        "deadbeef",
+                        "deadca1f",
+                        "deadca2f",
+                        "deadca3f",
+                        "deadca4f"
+                    ]
+                }
+            }
+            "#
+        .to_string();
+
+        let configuration = unindent::unindent(
+            r#"
+            {
+                "overrides": {
+                    "deadbeef": 2,
+                    "deadca1f": "3",
+                    "deadca2f": false,
+                    "deadca3f": "string0",
+                    "deadca4f": "new_field",
+                    "not_on_whitelist1": "not_on_whitelist"
+                }
+            }
+            "#,
+        );
+
+        let old_config = serde_json::from_str::<super::ConfigMap>(&config_json).unwrap();
+
+        let new_config = super::generate_config_json_migration(
+            &serde_json::from_str(&schema).unwrap(),
+            &serde_json::from_str(&configuration).unwrap(),
+            &old_config,
+        )
+        .unwrap();
+
+        assert_eq!(new_config.get("deadbeef").unwrap(), 2);
+        assert_eq!(new_config.get("deadca1f").unwrap(), "3");
+        assert_eq!(new_config.get("deadca2f").unwrap(), false);
+        assert_eq!(new_config.get("deadca3f").unwrap(), "string0");
+        assert_eq!(new_config.get("deadca4f").unwrap(), "new_field");
+        assert!(new_config.get("not_on_whitelist1").is_none());
+    }
+}

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -119,7 +119,7 @@ mod tests {
             &mut config,
         );
 
-        assert_eq!(has_config_json_migrations, true);
+        assert!(has_config_json_migrations);
         assert_eq!(config.get("deadbeef").unwrap(), 2);
         assert_eq!(config.get("deadca1f").unwrap(), "3");
         assert_eq!(config.get("deadca2f").unwrap(), false);

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -6,12 +6,12 @@ use crate::schema::validate_schema_version;
 use anyhow::{anyhow, Context, Result};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
-pub struct Configuration {
+pub struct RemoteConfiguration {
     pub services: HashMap<String, HashMap<String, String>>,
     pub schema_version: String,
 }
 
-impl Configuration {
+impl RemoteConfiguration {
     pub fn get_config_contents<'a>(
         &'a self,
         service_id: &str,
@@ -42,7 +42,7 @@ pub fn fetch_configuration(
     config_url: &str,
     root_certificate: Option<reqwest::Certificate>,
     retry: bool,
-) -> Result<Configuration> {
+) -> Result<RemoteConfiguration> {
     fetch_configuration_impl(config_url, root_certificate, retry)
         .context("Fetching configuration failed")
 }
@@ -51,7 +51,7 @@ fn fetch_configuration_impl(
     config_url: &str,
     root_certificate: Option<reqwest::Certificate>,
     retry: bool,
-) -> Result<Configuration> {
+) -> Result<RemoteConfiguration> {
     let client = build_reqwest_client(root_certificate)?;
 
     let request_fn = if retry {
@@ -159,10 +159,10 @@ mod tests {
     }"#;
 
     #[test]
-    fn parse_configuration_v1() {
-        let parsed: Configuration = serde_json::from_str(JSON_DATA).unwrap();
+    fn parse_configuration() {
+        let parsed: RemoteConfiguration = serde_json::from_str(JSON_DATA).unwrap();
 
-        let expected = Configuration {
+        let expected = RemoteConfiguration {
             services: hashmap! {
                 "openvpn".into() => hashmap!{
                     "config".into() => "main configuration here".into(),

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -4,6 +4,8 @@ use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 
+pub type OverridesMap = HashMap<String, serde_json::Value>;
+
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct RemoteConfiguration {
     pub services: HashMap<String, HashMap<String, String>>,
@@ -12,7 +14,7 @@ pub struct RemoteConfiguration {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct ConfigMigrationInstructions {
-    pub overrides: HashMap<String, serde_json::Value>,
+    pub overrides: OverridesMap,
 }
 
 impl RemoteConfiguration {

--- a/src/update.rs
+++ b/src/update.rs
@@ -6,7 +6,7 @@ use crate::config_json::read_config_json;
 use crate::join::reconfigure;
 
 pub fn update(args: &Args) -> Result<()> {
-    let config_json = read_config_json(&args.config_json_path)?;
+    let mut config_json = read_config_json(&args.config_json_path)?;
 
-    reconfigure(args, &config_json, false)
+    reconfigure(args, &mut config_json, false)
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -77,7 +77,9 @@ fn join() {
                 }}
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {{
+                "whitelist": ["logsEndpoint"]
+            }}
         }}
         "#
     );
@@ -99,7 +101,9 @@ fn join() {
                     "mock-3": "MOCK-3-0123456789"
                 }
             },
-            "schema_version": "1.0.0"
+            "config": {
+                "overrides": {}
+            }
         }
         "#,
     );
@@ -257,7 +261,9 @@ fn join_flasher() {
                 }}
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {{
+                "whitelist": ["logsEndpoint"]
+            }}
         }}
         "#
     );
@@ -272,7 +278,9 @@ fn join_flasher() {
                     "mock-1": "MOCK-1-АБВГДЕЖЗИЙ"
                 }
             },
-            "schema_version": "1.0.0"
+            "config": {
+                "overrides": {}
+            }
         }
         "#,
     );
@@ -392,7 +400,9 @@ fn join_with_root_certificate() {
             "services": [
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {
+                "whitelist": ["logsEndpoint"]
+            }
         }
         "#;
 
@@ -403,7 +413,9 @@ fn join_with_root_certificate() {
         {
             "services": {
             },
-            "schema_version": "1.0.0"
+            "config": {
+                "overrides": {}
+            }
         }
         "#,
     );
@@ -515,7 +527,9 @@ fn incompatible_device_types() {
             "services": [
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {
+                "whitelist": ["logsEndpoint"]
+            }
         }
         "#,
     );
@@ -608,7 +622,9 @@ fn reconfigure() {
             "services": [
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {
+                "whitelist": ["logsEndpoint"]
+            }
         }
         "#,
     );
@@ -620,7 +636,9 @@ fn reconfigure() {
         {
             "services": {
             },
-            "schema_version": "1.0.0"
+            "config": {
+                "overrides": {}
+            }
         }
         "#,
     );
@@ -751,7 +769,9 @@ fn reconfigure_stored() {
             "services": [
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {
+                "whitelist": ["logsEndpoint"]
+            }
         }
         "#,
     );
@@ -763,7 +783,9 @@ fn reconfigure_stored() {
         {
             "services": {
             },
-            "schema_version": "1.0.0"
+            "config": {
+                "overrides": {}
+            }
         }
         "#,
     );
@@ -935,7 +957,9 @@ fn update() {
                 }}
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {{
+                "whitelist": ["logsEndpoint"]
+            }}
         }}
         "#
     );
@@ -961,7 +985,9 @@ fn update() {
                     "mock-3": "MOCK-3-0123456789"
                 }
             },
-            "schema_version": "1.0.0"
+            "config": {
+                "overrides": {}
+            }
         }
         "#,
     );
@@ -1097,7 +1123,9 @@ fn update_no_config_changes() {
                 }}
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {{
+                "whitelist": ["logsEndpoint"]
+            }}
         }}
         "#
     );
@@ -1122,7 +1150,9 @@ fn update_no_config_changes() {
                     "mock-3": "MOCK-3-0123456789"
                 }
             },
-            "schema_version": "1.0.0"
+            "config": {
+                "overrides": {}
+            }
         }
         "#,
     );
@@ -1211,7 +1241,9 @@ fn update_with_root_certificate() {
             "services": [
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {
+                "whitelist": ["logsEndpoint"]
+            }
         }
         "#;
 
@@ -1222,7 +1254,9 @@ fn update_with_root_certificate() {
         {
             "services": {
             },
-            "schema_version": "1.0.0"
+            "config": {
+                "overrides": {}
+            }
         }
         "#,
     );
@@ -1271,7 +1305,9 @@ fn update_unmanaged() {
             "services": [
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {
+                "whitelist": ["logsEndpoint"]
+            }
         }
         "#;
 
@@ -1282,7 +1318,9 @@ fn update_unmanaged() {
         {
             "services": {
             },
-            "schema_version": "1.0.0"
+            "config": {
+                "overrides": {}
+            }
         }
         "#,
     );
@@ -1361,7 +1399,9 @@ fn leave() {
                 }}
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint", "vpnPort", "registryEndpoint", "deltaEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {{
+                "whitelist": ["logsEndpoint"]
+            }}
         }}
         "#
     );
@@ -1378,7 +1418,9 @@ fn leave() {
                     "mock-3": "MOCK-3-0123456789"
                 }
             },
-            "schema_version": "1.0.0"
+            "config": {
+                "overrides": {}
+            }
         }
         "#,
     );
@@ -1461,7 +1503,9 @@ fn leave_unmanaged() {
             "services": [
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {
+                "whitelist": ["logsEndpoint"]
+            }
         }
         "#,
     );
@@ -1473,7 +1517,9 @@ fn leave_unmanaged() {
         {
             "services": {
             },
-            "schema_version": "1.0.0"
+            "config": {
+                "overrides": {}
+            }
         }
         "#,
     );
@@ -1517,7 +1563,9 @@ fn generate_api_key_unmanaged() {
             "services": [
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {
+                "whitelist": ["logsEndpoint"]
+            }
         }
         "#,
     );
@@ -1576,7 +1624,9 @@ fn generate_api_key_already_generated() {
             "services": [
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {
+                "whitelist": ["logsEndpoint"]
+            }
         }
         "#,
     );
@@ -1635,7 +1685,9 @@ fn generate_api_key_reuse() {
             "services": [
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {
+                "whitelist": ["logsEndpoint"]
+            }
         }
         "#,
     );
@@ -1717,7 +1769,9 @@ fn generate_api_key_new() {
             "services": [
             ],
             "keys": ["apiKey", "apiEndpoint", "vpnEndpoint"],
-            "schema_version": "1.0.0"
+            "config": {
+                "whitelist": ["logsEndpoint"]
+            }
         }
         "#,
     );


### PR DESCRIPTION
This also includes os-config querying /os/v2/config instead, which has a different response format. The changes to the response format are reflected in the updated tests, and the API PR for the change in the backend is linked (and should be merged and tested first). The linked meta-balena PR should be merged with both the schema and os-config binary change.

See: https://balena.fibery.io/Work/Improvement/os-config-improving-the-interface-for-config.json-modification-901
See: https://github.com/balena-os/meta-balena/pull/3227
See: https://github.com/balena-io/open-balena-api/pull/1394
Signed-off-by: Christina Ying Wang <christina@balena.io>
Change-type: minor
