### PR TITLE
Wait for extract-balena-ca after changing config.json

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use crate::systemd::service_exists;
 
 pub const SUPERVISOR_SERVICE: &str = "balena-supervisor.service";
+pub const EXTRACT_BALENA_CA_SERVICE: &str = "extract-balena-ca.service";
 
 const CONFIG_ROUTE: &str = "/os/v1/config";
 const OS_CONFIG_PATH: &str = "/etc/os-config.json";
@@ -33,6 +34,7 @@ pub struct Args {
     pub config_json_path: PathBuf,
     pub json_config: Option<String>,
     pub supervisor_exists: bool,
+    pub extract_balena_service_exists: bool,
 }
 
 pub fn get_cli_args() -> Args {
@@ -70,6 +72,7 @@ pub fn get_cli_args() -> Args {
     let os_config_path = get_os_config_path();
     let config_json_path = get_config_json_path();
     let supervisor_exists = service_exists(SUPERVISOR_SERVICE);
+    let extract_balena_service_exists = service_exists(EXTRACT_BALENA_CA_SERVICE);
 
     Args {
         subcommand,
@@ -78,6 +81,7 @@ pub fn get_cli_args() -> Args {
         config_json_path,
         json_config,
         supervisor_exists,
+        extract_balena_service_exists,
     }
 }
 

--- a/src/join.rs
+++ b/src/join.rs
@@ -1,7 +1,7 @@
 use crate::fs;
 use std::path::Path;
 
-use crate::args::{Args, SUPERVISOR_SERVICE};
+use crate::args::{Args, EXTRACT_BALENA_CA_SERVICE, SUPERVISOR_SERVICE};
 use crate::config_json::{
     get_api_endpoint, get_root_certificate, merge_config_json, read_config_json, write_config_json,
     ConfigMap,
@@ -21,6 +21,11 @@ pub fn join(args: &Args) -> Result<()> {
         clean_config_json_keys(&mut config_json, &schema);
 
         merge_config_json(&mut config_json, json_config)?;
+
+        if args.extract_balena_service_exists {
+            let _ = systemd::start_service(EXTRACT_BALENA_CA_SERVICE);
+            let _ = systemd::await_service_exit(EXTRACT_BALENA_CA_SERVICE);
+        }
     } else {
         unreachable!()
     };


### PR DESCRIPTION
When config.json changes on balena join, the
extract-balena-ca.service runs automatically. We should
wait for this service to finish so that the ca is
refreshed before reading balenaRootCA

Change-type: patch