### PR TITLE
Add auth. header to /os/v1/config requests

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -85,7 +85,7 @@ pub fn get_os_config_path() -> PathBuf {
     path_buf(&try_redefined(OS_CONFIG_PATH, OS_CONFIG_PATH_REDEFINE))
 }
 
-fn get_config_json_path() -> PathBuf {
+pub fn get_config_json_path() -> PathBuf {
     if get_flasher_flag_path().exists() {
         get_config_json_flasher_path()
     } else {

--- a/src/config_json.rs
+++ b/src/config_json.rs
@@ -179,7 +179,7 @@ fn strip_api_endpoint(api_endpoint: &str) -> String {
     }
 }
 
-fn get_api_key(config_json: &ConfigMap) -> Result<Option<String>> {
+pub fn get_api_key(config_json: &ConfigMap) -> Result<Option<String>> {
     if let Some(value) = config_json.get("deviceApiKey") {
         if let Some(api_key) = value.as_str() {
             Ok(Some(api_key.to_string()))


### PR DESCRIPTION
* this allows the API to identify devices requesting configuration and apply routing logic (e.g. switch from TCP to UDP OpenVPN configuration)

* https://github.com/balena-os/meta-balena/pull/3443/commits/c401ebbf551420a0c2a91eff3cb0ecd83f12a056

change-type: minor